### PR TITLE
rspec fails without byebug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'cucumber'
   gem 'cucumber-sinatra'
   gem 'launchy'
+  gem 'byebug'
   gem 'rspec'
   gem 'shotgun'
   gem 'database_cleaner'


### PR DESCRIPTION
Also, bundler had to reinstall most of the gems, which was strange. Different versions for some reason?
